### PR TITLE
example: add an `agent-daemonset.yaml` example

### DIFF
--- a/example/agent-daemonset.yaml
+++ b/example/agent-daemonset.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sensu-agent
+spec:
+  template:
+    metadata:
+      labels:
+        name: sensu-agent
+    spec:
+      containers:
+        - name: sensu-agent
+          image: sensu/sensu:2.0.0-beta.3.1
+          command: ["/opt/sensu/bin/sensu-agent", "start", "--id", "$(MY_NODE_NAME)", "--subscriptions", "$(MY_NODE_NAME),k8s-node"]
+          env:
+            - name: SENSU_BACKEND_URL
+              value: ws://example-sensu-cluster-agent.default.svc.cluster.local:8081
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName


### PR DESCRIPTION
Add a simple `agent-daemonset.yaml` examples for keepalive checks of all
nodes in a Kubernetes cluster.

For more specific checks, users probably need to provide their own base
image and potentially also grant more privileges.